### PR TITLE
Revive autocloser and add 'no observations' flags function for datacheck web

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - pyyaml
   - pydot
   - pydotplus
+  - psutil
   - gammapy>=0.18
   - h5py
   - joblib

--- a/osa/scripts/copy_datacheck.py
+++ b/osa/scripts/copy_datacheck.py
@@ -6,21 +6,19 @@ directories whenever they are needed.
 
 import itertools
 import logging
-import subprocess
 from pathlib import Path
 
 from osa.configs import options
 from osa.configs.config import cfg
 from osa.utils.cliopts import copy_datacheck_parsing
 from osa.utils.logging import MyFormatter
-from osa.utils.utils import lstdate_to_dir, is_day_closed
-
-
-__all__ = [
-    "copy_files",
-    "create_destination_dir",
-    "set_no_observations_flag"
-]
+from osa.utils.utils import (
+    lstdate_to_dir,
+    is_day_closed,
+    create_directories_datacheck_web,
+    set_no_observations_flag,
+    copy_files_datacheck_web,
+)
 
 log = logging.getLogger(__name__)
 
@@ -30,10 +28,6 @@ handler = logging.StreamHandler()
 handler.setFormatter(fmt)
 log.addHandler(handler)
 log.setLevel(logging.INFO)
-
-
-analysis_products = ["drs4", "enf_calibration", "dl1"]
-datacheck_basedir = Path(cfg.get("WEBSERVER", "DATACHECK"))
 
 
 def main():
@@ -58,85 +52,13 @@ def main():
     files_to_transfer = list(itertools.chain(*list_of_files))
 
     log.debug("Creating directories")
-    create_destination_dir(cfg.get("WEBSERVER", "HOST"), nightdir, options.prod_id)
+    create_directories_datacheck_web(cfg.get("WEBSERVER", "HOST"), nightdir, options.prod_id)
     if not files_to_transfer and is_day_closed():
         log.warning("No observations. No files to be copied")
         set_no_observations_flag(cfg.get("WEBSERVER", "HOST"), nightdir, options.prod_id)
     else:
         log.debug("Transferring files")
-        copy_files(cfg.get("WEBSERVER", "HOST"), nightdir, files_to_transfer)
-
-
-def create_destination_dir(host, datedir, prod_id):
-    """Create destination directories for drs4, enf_calibration
-    and dl1 products in the data-check webserver via ssh. It also copies
-    the index.php file needed to build the directory tree structure.
-
-    Parameters
-    ----------
-    host
-    datedir
-    prod_id
-    """
-
-    # Create directory and copy the index.php to each directory
-    for product in analysis_products:
-        destination_dir = datacheck_basedir / product / prod_id / datedir
-        cmd = ["ssh", host, "mkdir", "-p", destination_dir]
-        subprocess.run(cmd, capture_output=True)
-        cmd = ["scp", cfg.get("WEBSERVER", "INDEXPHP"), f"{host}:{destination_dir}/."]
-        subprocess.run(cmd, capture_output=True)
-
-
-def set_no_observations_flag(host, datedir, prod_id):
-    """Create a flag file indicating that are no
-    observations on a given date.
-
-    Parameters
-    ----------
-    host
-    datedir
-    prod_id
-    """
-
-    for product in analysis_products:
-        try:
-            # Check if destination directory exists, otherwise create it
-            destination_dir = datacheck_basedir / product / prod_id / datedir
-            no_observations_flag = destination_dir / "no_observations"
-            cmd = ["ssh", host, "touch", no_observations_flag]
-            subprocess.check_output(cmd)
-        except subprocess.CalledProcessError as e:
-            log.warning(f"Destination directory does not exists. {e}")
-
-
-def copy_files(host, datedir, file_list):
-    """
-
-    Parameters
-    ----------
-    host
-    datedir
-    files
-    """
-    # FIXME: Check if files exists already at webserver CHECK HASH
-    datacheck_basedir = Path(cfg.get("WEBSERVER", "DATACHECK"))
-    # Copy files to server
-    for file_to_transfer in file_list:
-        if "drs4" in str(file_to_transfer):
-            destination_dir = datacheck_basedir / "drs4" / options.prod_id / datedir
-            cmd = ["scp", str(file_to_transfer), f"{host}:{destination_dir}/."]
-            subprocess.run(cmd)
-
-        elif "calibration" in str(file_to_transfer):
-            destination_dir = datacheck_basedir / "enf_calibration" / options.prod_id / datedir
-            cmd = ["scp", file_to_transfer, f"{host}:{destination_dir}/."]
-            subprocess.run(cmd)
-
-        elif "datacheck" in str(file_to_transfer):
-            destination_dir = datacheck_basedir / "dl1" / options.prod_id / datedir
-            cmd = ["scp", file_to_transfer, f"{host}:{destination_dir}/."]
-            subprocess.run(cmd)
+        copy_files_datacheck_web(cfg.get("WEBSERVER", "HOST"), nightdir, files_to_transfer)
 
 
 if __name__ == "__main__":

--- a/osa/scripts/copy_datacheck.py
+++ b/osa/scripts/copy_datacheck.py
@@ -13,9 +13,14 @@ from osa.configs import options
 from osa.configs.config import cfg
 from osa.utils.cliopts import copy_datacheck_parsing
 from osa.utils.logging import MyFormatter
-from osa.utils.utils import lstdate_to_dir
+from osa.utils.utils import lstdate_to_dir, is_day_closed
 
-__all__ = ["copy_files", "create_destination_dir", "is_merge_process_finished"]
+
+__all__ = [
+    "copy_files",
+    "create_destination_dir",
+    "set_no_observations_flag"
+]
 
 log = logging.getLogger(__name__)
 
@@ -27,6 +32,10 @@ logging.root.addHandler(handler)
 log.setLevel(logging.INFO)
 
 
+analysis_products = ["drs4", "enf_calibration", "dl1"]
+datacheck_basedir = Path(cfg.get("WEBSERVER", "DATACHECK"))
+
+
 def main():
     """
     Get analysis products to be copied to the webserver,
@@ -35,34 +44,33 @@ def main():
     # Set cli options and arguments
     copy_datacheck_parsing()
 
-    # Check of merging process has already finished
-    if is_merge_process_finished():
-        # Check if files exists in local disk
-        nightdir = lstdate_to_dir(options.date)
-        analysis_log_dir = Path(cfg.get("LST1", "ANALYSISDIR")) / nightdir / options.prod_id / "log"
-        dl1_dir = Path(cfg.get("LST1", "DL1DIR")) / nightdir / options.prod_id / options.dl1_prod_id
-        dl1_longterm_daily = Path("/fefs/aswg/data/real/OSA/DL1DataCheck_LongTerm") / "v0.7" / nightdir
+    # Check if files exists in local disk
+    nightdir = lstdate_to_dir(options.date)
+    analysis_log_dir = Path(cfg.get("LST1", "ANALYSISDIR")) / nightdir / options.prod_id / "log"
+    dl1_dir = Path(cfg.get("LST1", "DL1DIR")) / nightdir / options.prod_id / options.dl1_prod_id
+    dl1_longterm_daily = Path("/fefs/aswg/data/real/OSA/DL1DataCheck_LongTerm") / "v0.7" / nightdir
 
-        drs4_pdf = [file for file in analysis_log_dir.glob("drs4*.pdf")]
-        calib_pdf = [file for file in analysis_log_dir.glob("calibration*.pdf")]
-        dl1_pdf = [file for file in dl1_dir.glob("*datacheck*.pdf")]
-        dl1_longterm_daily = [file for file in dl1_longterm_daily.glob("*datacheck*")]
-        list_of_files = [drs4_pdf, calib_pdf, dl1_pdf, dl1_longterm_daily]
-        files_to_transfer = list(itertools.chain(*list_of_files))
+    drs4_pdf = [file for file in analysis_log_dir.glob("drs4*.pdf")]
+    calib_pdf = [file for file in analysis_log_dir.glob("calibration*.pdf")]
+    dl1_pdf = [file for file in dl1_dir.glob("*datacheck*.pdf")]
+    dl1_longterm_daily = [file for file in dl1_longterm_daily.glob("*datacheck*")]
+    list_of_files = [drs4_pdf, calib_pdf, dl1_pdf, dl1_longterm_daily]
+    files_to_transfer = list(itertools.chain(*list_of_files))
 
-        log.debug("Creating directories")
-        create_destination_dir(cfg.get("WEBSERVER", "HOST"), nightdir, options.prod_id)
-        if not files_to_transfer:
-            log.warning("No files to be copied")
-        else:
-            log.debug("Transferring files")
-            copy_files(cfg.get("WEBSERVER", "HOST"), nightdir, files_to_transfer)
+    log.debug("Creating directories")
+    create_destination_dir(cfg.get("WEBSERVER", "HOST"), nightdir, options.prod_id)
+    if not files_to_transfer and is_day_closed():
+        log.warning("No observations, hence no files to be copied")
+        set_no_observations_flag(cfg.get("WEBSERVER", "HOST"), nightdir, options.prod_id)
     else:
-        log.warning("Files still not produced")
+        log.debug("Transferring files")
+        copy_files(cfg.get("WEBSERVER", "HOST"), nightdir, files_to_transfer)
 
 
 def create_destination_dir(host, datedir, prod_id):
-    """
+    """Create destination directories for drs4, enf_calibration
+    and dl1 products in the data-check webserver via ssh. It also copies
+    the index.php file needed to build the directory tree structure.
 
     Parameters
     ----------
@@ -70,14 +78,30 @@ def create_destination_dir(host, datedir, prod_id):
     datedir
     prod_id
     """
-    datacheck_basedir = Path(cfg.get("WEBSERVER", "DATACHECK"))
 
     # Create directory and copy the index.php to each directory
-    for product in ["drs4", "enf_calibration", "dl1"]:
+    for product in analysis_products:
         destination_dir = datacheck_basedir / product / prod_id / datedir
         cmd = ["ssh", host, "mkdir", "-p", destination_dir]
         subprocess.run(cmd)
         cmd = ["scp", cfg.get("WEBSERVER", "INDEXPHP"), f"{host}:{destination_dir}/."]
+        subprocess.run(cmd)
+
+
+def set_no_observations_flag(host, datedir, prod_id):
+    """Create a flag file indicating that are no
+    observations on a given date.
+
+    Parameters
+    ----------
+    host
+    datedir
+    prod_id
+    """
+    for product in analysis_products:
+        destination_dir = datacheck_basedir / product / prod_id / datedir
+        no_observations_flag = destination_dir / "no_observations"
+        cmd = ["ssh", host, "touch", no_observations_flag]
         subprocess.run(cmd)
 
 
@@ -91,9 +115,8 @@ def copy_files(host, datedir, file_list):
     files
     """
     # FIXME: Check if files exists already at webserver CHECK HASH
-    # Copy PDF files
     datacheck_basedir = Path(cfg.get("WEBSERVER", "DATACHECK"))
-    # Scopy files
+    # Copy files to server
     for file_to_transfer in file_list:
         if "drs4" in str(file_to_transfer):
             destination_dir = datacheck_basedir / "drs4" / options.prod_id / datedir
@@ -109,12 +132,6 @@ def copy_files(host, datedir, file_list):
             destination_dir = datacheck_basedir / "dl1" / options.prod_id / datedir
             cmd = ["scp", file_to_transfer, f"{host}:{destination_dir}/."]
             subprocess.run(cmd)
-
-
-def is_merge_process_finished():
-    # TODO: still not implemented
-    #  check that no lstchain_check_dl1 is still running and pdf files already exist
-    return True
 
 
 if __name__ == "__main__":

--- a/osa/scripts/copy_datacheck.py
+++ b/osa/scripts/copy_datacheck.py
@@ -60,7 +60,7 @@ def main():
     log.debug("Creating directories")
     create_destination_dir(cfg.get("WEBSERVER", "HOST"), nightdir, options.prod_id)
     if not files_to_transfer and is_day_closed():
-        log.warning("No observations, hence no files to be copied")
+        log.warning("No observations. No files to be copied")
         set_no_observations_flag(cfg.get("WEBSERVER", "HOST"), nightdir, options.prod_id)
     else:
         log.debug("Transferring files")

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "prov",
         "pydot",
         "pydotplus",
+        "psutil",
     ],
     package_data={
         'osa': [


### PR DESCRIPTION
- Add missing `psutil` requirement to setup.
- **Bring autocloser back to life**. Clean up `autocloser.py`. It can be used now as a superscript that handles the closing procedure. It checks that all sequences are completed and calls in turn `closer.py`. These checks are done looping over all existing sequences (run-wise).
- Refactoring of `copy_datacheck`. Some functions have been moved to `osa.utils` to be used from autocloser. All the copying of datacheck PDF files should be handled at some point by autocloser. However, it is also autocloser (via closer) the script that produces the merging of datachecks files. Thus, it should wait somehow until those jobs are finished.

