### PR TITLE
Sacct starttime to 1 previous week instead of the default

### DIFF
--- a/osa/jobs/job.py
+++ b/osa/jobs/job.py
@@ -2,13 +2,13 @@
 Functions to handle the job submission using SLURM
 """
 
+import datetime
 import logging
 import os
 import subprocess
 import sys
 import time
 from glob import glob
-import datetime
 
 import pandas as pd
 

--- a/osa/reports/report.py
+++ b/osa/reports/report.py
@@ -8,7 +8,6 @@ from osa.configs import config, options
 from osa.configs.config import cfg
 from osa.rawcopy.raw import getrawdir
 from osa.utils.iofile import appendtofile
-from osa.utils.standardhandle import gettag
 
 log = logging.getLogger(__name__)
 
@@ -38,7 +37,6 @@ def header(message):
     ----------
     message
     """
-    tag = gettag()
     framesize = size()
     if len(message) < framesize - 2:
         prettyframe = int((framesize - 2 - len(message)) / 2) * "="

--- a/osa/scripts/closer.py
+++ b/osa/scripts/closer.py
@@ -169,36 +169,34 @@ def ask_for_closing():
     """
 
     if options.noninteractive:
-        # in not-interactive mode, we assume the answer is yes
-        pass
-    else:
-        answer_check = False
-        while not answer_check:
-            try:
+        return
+    answer_check = False
+    while not answer_check:
+        try:
+            if options.simulate:
                 question = "Close that day? (y/n): "
-                if options.simulate:
-                    question += "[SIMULATE ongoing] "
-                # FIXME: figure out where raw_input comes from. I set it to answer no
-                # answer_user = input(question)
-                answer_user = "n"
-            except KeyboardInterrupt:
-                log.warning("Program quitted by user. No answer")
-                sys.exit(1)
-            except EOFError as ErrorValue:
-                log.exception("End of file not expected", ErrorValue)
+                question += "[SIMULATE ongoing] "
+            # FIXME: figure out where raw_input comes from. I set it to answer no
+            # answer_user = input(question)
+            answer_user = "n"
+        except KeyboardInterrupt:
+            log.warning("Program quitted by user. No answer")
+            sys.exit(1)
+        except EOFError as ErrorValue:
+            log.exception("End of file not expected", ErrorValue)
+        else:
+            answer_check = True
+            if answer_user in {"n", "N"}:
+                # the user does not want to close
+                log.info(
+                    f"Day {options.date} for {options.tel_id} will remain open unless closing is forced"
+                )
+                sys.exit(0)
+            elif answer_user in {"y", "Y"}:
+                continue
             else:
-                answer_check = True
-                if answer_user == "n" or answer_user == "N":
-                    # the user does not want to close
-                    log.info(
-                        f"Day {options.date} for {options.tel_id} will remain open unless closing is forced"
-                    )
-                    sys.exit(0)
-                elif answer_user == "y" or answer_user == "Y":
-                    continue
-                else:
-                    log.warning("Answer not understood, please type y or n")
-                    answer_check = False
+                log.warning("Answer not understood, please type y or n")
+                answer_check = False
 
 
 def notify_neither_data_nor_reason_given():
@@ -228,7 +226,7 @@ def post_process(seq_tuple):
     merge_dl2(seq_list)
 
     if options.seqtoclose is None:
-        return set_closed_with_file(analysis_text)
+        return set_closed_with_file()
     return False
 
 
@@ -244,14 +242,13 @@ def post_process_files(seq_list):
 
     output_files_set = set(Path(options.directory).rglob("*Run*"))
 
-    DL1_RE = re.compile(fr"{options.directory}/dl1(?:.*).(?:h5|hdf5|hdf)")
-    DL1AB_RE = re.compile(fr"{options.dl1_prod_id}(?:.*)/dl1(?:.*).(?:h5|hdf5|hdf)")
-    DL2_RE = re.compile(fr"{options.dl2_prod_id}(?:.*)/dl2(?:.*).(?:h5|hdf5|hdf)")
-    MUONS_RE = re.compile(r"muons(?:.*).fits")
-    DATACHECK_RE = re.compile(r"datacheck_dl1(?:.*).(?:h5|hdf5|hdf)")
-    CALIB_RE = re.compile(r"/calibration(?:.*).(?:h5|hdf5|hdf)")
-    TIMECALIB_RE = re.compile(r"/time_calibration(?:.*).(?:h5|hdf5|hdf)")
-    PEDESTAL_RE = re.compile(r"drs4(?:.*).fits")
+    DL1AB_RE = re.compile(fr"{options.dl1_prod_id}.*/dl1.*.(?:h5|hdf5|hdf)")
+    DL2_RE = re.compile(fr"{options.dl2_prod_id}.*/dl2.*.(?:h5|hdf5|hdf)")
+    MUONS_RE = re.compile(r"muons.*.fits")
+    DATACHECK_RE = re.compile(r"datacheck_dl1.*.(?:h5|hdf5|hdf)")
+    CALIB_RE = re.compile(r"/calibration.*.(?:h5|hdf5|hdf)")
+    TIMECALIB_RE = re.compile(r"/time_calibration.*.(?:h5|hdf5|hdf)")
+    PEDESTAL_RE = re.compile(r"drs4.*.fits")
 
     pattern_files = dict(
         [
@@ -364,14 +361,14 @@ def register_non_existing_file(file_path_str, concept, seq_list):
         createclosed(s.closed)
 
 
-def set_closed_with_file(ana_text):
+def set_closed_with_file():
     """Write the analysis report to the closer file."""
 
     closer_file = getlockfile()
     is_closed = False
     if not options.simulate:
         # Generate NightFinished lock file
-        is_closed = createlock(closer_file, ana_text)
+        is_closed = createlock(closer_file)
     else:
         log.info(f"SIMULATE Creation of lock file {closer_file}")
 
@@ -577,7 +574,7 @@ def merge_dl2(sequence_list):
                 options.directory,
                 "-o",
                 f"log/slurm_merge_dl2_{sequence.run:05d}_%j.log",
-                f"lstchain_merge_hdf5_files",
+                "lstchain_merge_hdf5_files",
                 f"--input-dir={dl2_dir}",
                 f"--output-file={dl2_merged_file}",
                 "--no-image=True",

--- a/osa/utils/utils.py
+++ b/osa/utils/utils.py
@@ -25,6 +25,8 @@ __all__ = [
     "copy_files_datacheck_web",
     "lstdate_to_dir",
     "is_day_closed",
+    "date_in_yymmdd",
+    "time_to_seconds"
 ]
 
 log = logging.getLogger(__name__)
@@ -179,13 +181,12 @@ def get_dl2_prod_id():
     return options.dl2_prod_id
 
 
-def createlock(lockfile, content):
+def createlock(lockfile):
     """
 
     Parameters
     ----------
     lockfile
-    content
 
     Returns
     -------

--- a/osa/utils/utils.py
+++ b/osa/utils/utils.py
@@ -26,7 +26,11 @@ __all__ = [
     "lstdate_to_dir",
     "is_day_closed",
     "date_in_yymmdd",
-    "time_to_seconds"
+    "time_to_seconds",
+    "getlockfile",
+    "is_defined",
+    "destination_dir",
+    "createlock"
 ]
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
By default `sacct` returns the jobs in a 1-day period. Here it is set to one week in advance to deal with older jobs from previous days in the sequencer table.

Minor fixes and refactoring