### PR TITLE
Use get_lstchain_version calls consistently

### DIFF
--- a/osa/configs/options.py
+++ b/osa/configs/options.py
@@ -15,7 +15,6 @@ verbose = None
 warning = None
 nocheck = None
 no_dl2 = None
-lstchain_version = None
 prod_id = None
 calib_prod_id = None
 dl1_prod_id = None

--- a/osa/provenance/utils.py
+++ b/osa/provenance/utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from osa.configs import options
 from osa.configs.config import cfg
-from osa.utils.utils import lstdate_to_dir
+from osa.utils.utils import get_lstchain_version, lstdate_to_dir
 
 __all__ = ["parse_variables", "get_log_config", "store_conda_env_export"]
 
@@ -50,7 +50,7 @@ def parse_variables(class_instance):
 
         class_instance.ObservationRun = class_instance.args[5].split(".")[0]
         class_instance.ObservationDate = nightdir
-        class_instance.SoftwareVersion = options.lstchain_version
+        class_instance.SoftwareVersion = get_lstchain_version()
         class_instance.session_name = class_instance.ObservationRun
         class_instance.ProcessingConfigFile = options.configfile
 
@@ -83,7 +83,7 @@ def parse_variables(class_instance):
         class_instance.Analysisconfigfile_dl1 = configfile_dl1
         class_instance.ObservationRun = class_instance.args[0].split(".")[0]
         class_instance.ObservationDate = nightdir
-        class_instance.SoftwareVersion = options.lstchain_version
+        class_instance.SoftwareVersion = get_lstchain_version()
         class_instance.session_name = class_instance.ObservationRun
         class_instance.ProcessingConfigFile = options.configfile
 
@@ -99,7 +99,7 @@ def parse_variables(class_instance):
 
         class_instance.ObservationRun = class_instance.args[0].split(".")[0]
         class_instance.ObservationDate = nightdir
-        class_instance.SoftwareVersion = options.lstchain_version
+        class_instance.SoftwareVersion = get_lstchain_version()
         class_instance.session_name = class_instance.ObservationRun
         class_instance.ProcessingConfigFile = options.configfile
 
@@ -125,7 +125,7 @@ def parse_variables(class_instance):
         class_instance.Analysisconfigfile_dl2 = configfile_dl2
         class_instance.ObservationRun = class_instance.args[0].split(".")[0]
         class_instance.ObservationDate = nightdir
-        class_instance.SoftwareVersion = options.lstchain_version
+        class_instance.SoftwareVersion = get_lstchain_version()
         class_instance.session_name = class_instance.ObservationRun
         class_instance.ProcessingConfigFile = options.configfile
 

--- a/osa/utils/cliopts.py
+++ b/osa/utils/cliopts.py
@@ -472,8 +472,6 @@ def data_sequence_cli_parsing():
     else:
         options.dl2_prod_id = options.prod_id
 
-    options.lstchain_version = get_lstchain_version()
-
     return (
         opts.calib_file,
         opts.drs4_ped_file,
@@ -767,7 +765,6 @@ def provprocessparsing():
     options.configfile = os.path.abspath(opts.configfile)
     options.filter = opts.filter
     options.quit = opts.quit
-    options.lstchain_version = get_lstchain_version()
 
     if cfg.get("LST1", "DL1_PROD_ID") is not None:
         options.dl1_prod_id = get_dl1_prod_id()

--- a/osa/utils/cliopts.py
+++ b/osa/utils/cliopts.py
@@ -12,7 +12,6 @@ from osa.utils.utils import (
     get_calib_prod_id,
     get_dl1_prod_id,
     get_dl2_prod_id,
-    get_lstchain_version,
     get_prod_id,
     getcurrentdate,
     night_directory,

--- a/osa/utils/utils.py
+++ b/osa/utils/utils.py
@@ -118,9 +118,7 @@ def get_lstchain_version():
     lstchain_version: string
     """
     from lstchain import __version__
-
-    options.lstchain_version = "v" + __version__
-    return options.lstchain_version
+    return "v" + __version__
 
 
 def get_prod_id():


### PR DESCRIPTION
This PR uses `get_lstchain_version()` function calls to grab the software version in a consistent way where is needed in the code, also removing the `options.lstchain_version` global variable.