### PR TITLE
Capture code coverage in subprocesses

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+concurrency=multiprocessing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
           echo "Creating conda env"
           conda env create -n ci -f environment.yml
           conda activate ci
-          pip install pyflakes
           echo "Installing additional pip packages"
+          pip install pyflakes
           echo "pip install ."
           pip install .
 
@@ -47,12 +47,24 @@ jobs:
           pyflakes osa
 
       - name: Tests
+        env:
+          COVERAGE_PROCESS_START: True
+          PYTHONPATH: .
+
         run: |
           # github actions starts a new shell for each "step", so we need to
           # activate our env again
           source $CONDA/etc/profile.d/conda.sh
           conda activate ci
+
+          # to measure coverage when using subprocess for testing scripts we create sitecustomize.py
+          # as specified in https://coverage.readthedocs.io/en/latest/subprocess.html
+          # to initialize the coverage start up.
+          echo "create sitecustomize.py"
+          echo "import coverage; coverage.process_startup()" > $PYTHONPATH/sitecustomize.py
+
           pytest --basetemp=test_osa -v --cov --cov-report=xml osa
+          cat coverage.xml
 
       - name: Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Tests
         env:
-          COVERAGE_PROCESS_START: True
+          COVERAGE_PROCESS_START: .coveragerc
           PYTHONPATH: .
 
         run: |


### PR DESCRIPTION
This PR intends to capture code coverage in subprocesses within the CI, based on the info found in the documentation of coverage.py

- https://coverage.readthedocs.io/en/latest/subprocess.html
-  https://coverage.readthedocs.io/en/latest/config.html

